### PR TITLE
Fix WebSocket compression UTF-8 validation error

### DIFF
--- a/core-os/system/mla_stream_deflate.cpp
+++ b/core-os/system/mla_stream_deflate.cpp
@@ -888,7 +888,8 @@ mla_bool_t mla_stream_output_deflate_finish(mla_stream_output_t &output) {
         // LEN/NLEN bytes (00 00 FF FF). The 3 empty-block header bits from the
         // raw flush must still be written because they may share the same output
         // byte as the pending end-of-block bits.
-        __mla_deflate_bit_writer_write(state->writer, 0x01, 3);
+        // Important: BFINAL must be 0 for the standard 00 00 FF FF tail.
+        __mla_deflate_bit_writer_write(state->writer, 0x00, 3);
 
         // Byte-align so the kept prefix exactly matches a normal raw stream with
         // only the last four LEN/NLEN bytes removed.


### PR DESCRIPTION
Fixed a bug in the WebSocket permessage-deflate implementation where the trailing empty block incorrectly had the BFINAL bit set to 1. This caused standard WebSocket clients (like Node.js 'ws') to fail decompression or report UTF-8 validation errors because they expect the standard '00 00 FF FF' flush marker which corresponds to BFINAL=0. Verified the fix with unit tests and a Node.js reproduction script.

---
*PR created automatically by Jules for task [6869361043522668638](https://jules.google.com/task/6869361043522668638) started by @Christian-Schl*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebSocket stream compression finalization to ensure proper standards compliance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->